### PR TITLE
Add support for merge bemdecl

### DIFF
--- a/techs/merge-deps.js
+++ b/techs/merge-deps.js
@@ -98,7 +98,11 @@ module.exports = inherit(require('enb/lib/tech/base-tech'), {
                     cache.needRebuildFileList('source-file-list', sourceFilenames)
                 ) {
                     return vow.all(sourceDeps.map(function (source, i) {
-                            if (source) { return source.deps; }
+                            if (source.blocks) {
+                                return deps.fromBemdecl(source.blocks);
+                            } else if (source) {
+                                return source.deps;
+                            }
 
                             var filename = sourceFilenames[i];
 

--- a/techs/merge-deps.js
+++ b/techs/merge-deps.js
@@ -98,7 +98,7 @@ module.exports = inherit(require('enb/lib/tech/base-tech'), {
                     cache.needRebuildFileList('source-file-list', sourceFilenames)
                 ) {
                     return vow.all(sourceDeps.map(function (source, i) {
-                            if (source.blocks) {
+                            if (source && source.blocks) {
                                 return deps.fromBemdecl(source.blocks);
                             } else if (source) {
                                 return source.deps;


### PR DESCRIPTION
Add support for use https://github.com/enb-bem/enb-bem-techs#mergedeps tech with bemdecl files.
For example, the result of https://github.com/enb-bem/enb-bem-techs#levelstobemdecl can be used for merging with deps file.