### PR TITLE
fix(techs/files): for levels with common prefix

### DIFF
--- a/techs/files.js
+++ b/techs/files.js
@@ -1,4 +1,6 @@
-var inherit = require('inherit'),
+var path = require('path'),
+
+    inherit = require('inherit'),
     vow = require('vow'),
     deps = require('../lib/deps/deps'),
     enb = require('enb'),
@@ -119,7 +121,7 @@ module.exports = inherit(BaseTech, {
                                 var filename = file.fullname;
 
                                 levelPaths.forEach(function (levelPath, index) {
-                                    if (!uniqs[filename] && filename.indexOf(levelPath) === 0) {
+                                    if (!uniqs[filename] && filename.indexOf(levelPath + path.sep) === 0) {
                                         slices[index].push(file);
                                         uniqs[filename] = true;
                                     }


### PR DESCRIPTION
Fixes wrong files order for incoming levels path with common first part.

### FS
Levels:
- `path/to/level-1`
- `path/to/level-2`
- `path/to/level-10`

Decl: `['b']`

### Current behaviour:
Outgoing files:
- `path/to/level-1/b/b.js`
- `path/to/level-10/b/b.js`
- `path/to/level-2/b/b.js`

### Expected
Outgoing files:
- `path/to/level-1/b/b.js`
- `path/to/level-2/b/b.js`
- `path/to/level-10/b/b.js`
